### PR TITLE
Refactor data shortcodes to use shared utilities

### DIFF
--- a/_extensions/homepage/shortcodes/kpi-grid.lua
+++ b/_extensions/homepage/shortcodes/kpi-grid.lua
@@ -1,38 +1,24 @@
--- _extensions/homepage/shortcodes/kpi-grid.lua
-local function find_project_root(start)
-  local dir = start
-  while true do
-    local q1, q2 = dir .. "/_quarto.yml", dir .. "/_quarto.yaml"
-    local f = io.open(q1, "r") or io.open(q2, "r")
-    if f then f:close(); return dir end
-    local parent = pandoc.path.directory(dir)
-    if parent == dir or parent == "" or parent == "." then return "." end
-    dir = parent
-  end
-end
+local utils = require("../../utils")
 
-local function load_kpis()
-  local input = pandoc.path.normalize(quarto.doc.input_file or "")
-  local root  = find_project_root(pandoc.path.directory(input))
-  local path  = pandoc.path.normalize(root .. "/data/kpis.json")
-  local f = io.open(path, "r")
-  if not f then return {} end
-  local txt = f:read("*a"); f:close()
-  local ok, data = pcall(quarto.json.decode, txt)
-  if not ok or type(data) ~= "table" then return {} end
-  return data.kpis or {}
+local function render_kpi(k)
+  local icon  = utils.esc(k.icon or "")
+  local num   = utils.esc(k.num or "")
+  local label = utils.esc(k.label or "")
+  return table.concat({
+    '<div class="kpi">',
+      '<span class="bi ', icon, ' icon"></span>',
+      '<div class="num">', num, '</div>',
+      '<div class="label">', label, '</div>',
+    '</div>'
+  })
 end
 
 return {
   ["kpi-grid"] = function()
-    local kpis = load_kpis()
+    local kpis = utils.load_data_array("data/kpis.json", "kpis")
     local buf = { '<div class="kpis grid-3">' }
     for _, k in ipairs(kpis) do
-      table.insert(buf, '<div class="kpi">')
-      table.insert(buf, '<span class="bi ' .. (k.icon or "") .. ' icon"></span>')
-      table.insert(buf, '<div class="num">' .. tostring(k.num or "") .. '</div>')
-      table.insert(buf, '<div class="label">' .. (k.label or "") .. '</div>')
-      table.insert(buf, '</div>')
+      table.insert(buf, render_kpi(k))
     end
     table.insert(buf, '</div>')
     return pandoc.RawBlock("html", table.concat(buf, ""))

--- a/_extensions/homepage/shortcodes/partners.lua
+++ b/_extensions/homepage/shortcodes/partners.lua
@@ -1,37 +1,18 @@
--- _extensions/homepage/shortcodes/partners.lua
-local function find_project_root(start)
-  local dir = start
-  while true do
-    local q1, q2 = dir .. "/_quarto.yml", dir .. "/_quarto.yaml"
-    local f = io.open(q1, "r") or io.open(q2, "r")
-    if f then f:close(); return dir end
-    local parent = pandoc.path.directory(dir)
-    if parent == dir or parent == "" or parent == "." then return "." end
-    dir = parent
-  end
-end
+local utils = require("../../utils")
 
-local function load_partners()
-  local input = pandoc.path.normalize(quarto.doc.input_file or "")
-  local root  = find_project_root(pandoc.path.directory(input))
-  local path  = pandoc.path.normalize(root .. "/data/partners.json")
-  local f = io.open(path, "r")
-  if not f then return {} end
-  local txt = f:read("*a"); f:close()
-  local ok, data = pcall(quarto.json.decode, txt)
-  if not ok or type(data) ~= "table" then return {} end
-  return data.partners or {}
+local function render_partner(p)
+  local url  = utils.esc(p.url  or "#")
+  local logo = utils.esc(p.logo or "")
+  local name = utils.esc(p.name or "")
+  return '<a href="'..url..'"><img src="'..logo..'" alt="'..name..'"></a>'
 end
 
 return {
   ["partners"] = function()
-    local parts = load_partners()
+    local parts = utils.load_data_array("data/partners.json", "partners")
     local buf = { '<div class="brands">' }
     for _, p in ipairs(parts) do
-      local url  = p.url  or "#"
-      local logo = p.logo or ""
-      local name = p.name or ""
-      table.insert(buf, '<a href="'..url..'"><img src="'..logo..'" alt="'..name..'"></a>')
+      table.insert(buf, render_partner(p))
     end
     table.insert(buf, '</div>')
     return pandoc.RawBlock("html", table.concat(buf, ""))

--- a/_extensions/utils.lua
+++ b/_extensions/utils.lua
@@ -26,35 +26,61 @@ function utils.project_root_for_current_doc()
   return utils.find_project_root(start)
 end
 
--- Met en cache et charge data/members.json
-local MEMBERS_CACHE = nil
-function utils.load_members()
-  if MEMBERS_CACHE then return MEMBERS_CACHE end
+-- Chargement générique de fichiers JSON du dossier data/ avec cache mémoire
+local JSON_CACHE = {}
+local function load_project_json(relpath)
   local root = utils.project_root_for_current_doc()
-  local path = pandoc.path.normalize(root .. "/data/members.json")
+  local path = pandoc.path.normalize(root .. "/" .. relpath)
+  local cached = JSON_CACHE[path]
+  if cached ~= nil then
+    if cached == false then return nil end
+    return cached
+  end
   local f = io.open(path, "r")
   if not f then
-    MEMBERS_CACHE = { list = {}, byid = {} }
-    return MEMBERS_CACHE
+    JSON_CACHE[path] = false
+    return nil
   end
   local txt = f:read("*a"); f:close()
   local ok, data = pcall(quarto.json.decode, txt)
   if not ok or type(data) ~= "table" then
-    MEMBERS_CACHE = { list = {}, byid = {} }
-    return MEMBERS_CACHE
+    JSON_CACHE[path] = false
+    return nil
   end
+  JSON_CACHE[path] = data
+  return data
+end
+
+-- Renvoie un tableau depuis un fichier JSON (optionnellement sous une clé)
+function utils.load_data_array(relpath, key)
+  local data = load_project_json(relpath) or {}
+  if not key then
+    return type(data) == "table" and data or {}
+  end
+  local subset = data[key]
+  if type(subset) == "table" then return subset end
+  return {}
+end
+
+-- Met en cache et charge data/members.json
+local MEMBERS_CACHE = nil
+function utils.load_members()
+  if MEMBERS_CACHE then return MEMBERS_CACHE end
+  local data = load_project_json("data/members.json")
   local list, byid = {}, {}
-  for _, m in ipairs(data.members or {}) do
-    if m.id and m.name then
-      table.insert(list, m)
-      byid[m.id] = m
+  if type(data) == "table" then
+    for _, m in ipairs(data.members or {}) do
+      if m.id and m.name then
+        table.insert(list, m)
+        byid[m.id] = m
+      end
     end
   end
   MEMBERS_CACHE = { list = list, byid = byid }
   return MEMBERS_CACHE
 end
 
--- Fonction d’échappement HTML (utilisée dans les deux shortcodes)
+-- Fonction d’échappement HTML (utilisée dans les shortcodes)
 function utils.esc(s)
   s = tostring(s or "")
   return s:gsub("&", "&amp;"):gsub("<", "&lt;")


### PR DESCRIPTION
## Summary
- add a cached generic JSON loader in `_extensions/utils.lua`
- reuse the shared loader from the homepage KPI and partners shortcodes and escape rendered data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db970ecc8883268424ba6ec0916f84